### PR TITLE
Update to handle missing 'to'

### DIFF
--- a/mailparser/mailparser.py
+++ b/mailparser/mailparser.py
@@ -226,8 +226,12 @@ class MailParser(object):
 
     @property
     def to_(self):
-        return decode_header_part(
-            self._message.get('to', self._message.get('delivered-to')))
+        to_ = self._message.get('to')        
+        if not to_:
+            return None
+        else:
+            return decode_header_part(
+                self._message.get('to', self._message.get('delivered-to')))
 
     @property
     def from_(self):


### PR DESCRIPTION
While parsing archived emails I found about 1% of emails lacked a 'Delivered-to' field. When missing, returns None.